### PR TITLE
[feature/#22] 소셜 로그인/회원가입 구현

### DIFF
--- a/app/src/debug/java/com/teamfillin/fillin/FlipperInitializer.kt
+++ b/app/src/debug/java/com/teamfillin/fillin/FlipperInitializer.kt
@@ -8,7 +8,9 @@ import com.facebook.flipper.plugins.leakcanary2.FlipperLeakListener
 import com.facebook.flipper.plugins.leakcanary2.LeakCanary2FlipperPlugin
 import com.facebook.flipper.plugins.network.FlipperOkhttpInterceptor
 import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
+import com.facebook.flipper.plugins.sharedpreferences.SharedPreferencesFlipperPlugin
 import com.facebook.soloader.SoLoader
+import com.teamfillin.fillin.data.local.FILE_NAME
 import leakcanary.LeakCanary
 import okhttp3.OkHttpClient
 
@@ -24,6 +26,7 @@ object FlipperInitializer {
         client.addPlugin(InspectorFlipperPlugin(app, DescriptorMapping.withDefaults()))
         client.addPlugin(InspectorFlipperPlugin(app, DescriptorMapping.withDefaults()))
         client.addPlugin(flipperNetworkPlugin)
+        client.addPlugin(SharedPreferencesFlipperPlugin(app, FILE_NAME))
         client.addPlugin(LeakCanary2FlipperPlugin())
         client.start()
     }

--- a/app/src/main/java/com/teamfillin/fillin/config/di/RepositoryModule.kt
+++ b/app/src/main/java/com/teamfillin/fillin/config/di/RepositoryModule.kt
@@ -1,0 +1,15 @@
+package com.teamfillin.fillin.config.di
+
+import com.teamfillin.fillin.data.repository.AuthRepositoryImpl
+import com.teamfillin.fillin.domain.repository.AuthRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object RepositoryModule {
+    @Provides
+    fun provideAuthRepository(authRepository: AuthRepositoryImpl): AuthRepository = authRepository
+}

--- a/app/src/main/java/com/teamfillin/fillin/config/di/RetrofitModule.kt
+++ b/app/src/main/java/com/teamfillin/fillin/config/di/RetrofitModule.kt
@@ -7,14 +7,16 @@ import com.teamfillin.fillin.data.interceptor.AuthInterceptor
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import javax.inject.Singleton
 
 @Module
-@InstallIn(SingletonModule::class)
+@InstallIn(SingletonComponent::class)
 object RetrofitModule {
     @Provides
     @Singleton
@@ -27,6 +29,11 @@ object RetrofitModule {
         authInterceptor: Interceptor
     ): OkHttpClient {
         return OkHttpClient.Builder()
+            .addInterceptor(
+                HttpLoggingInterceptor().apply {
+                    level = HttpLoggingInterceptor.Level.BODY
+                }
+            )
             .addInterceptor(authInterceptor)
             .apply { FlipperInitializer.addFlipperNetworkPlguin(this).build() }
             .build()

--- a/app/src/main/java/com/teamfillin/fillin/config/di/RetrofitModule.kt
+++ b/app/src/main/java/com/teamfillin/fillin/config/di/RetrofitModule.kt
@@ -22,7 +22,6 @@ object RetrofitModule {
     @Singleton
     fun provideAuthInterceptor(authInterceptor: AuthInterceptor): Interceptor = authInterceptor
 
-
     @Provides
     @Singleton
     fun provideOkHttpInterceptor(
@@ -54,5 +53,5 @@ object RetrofitModule {
         .addConverterFactory(GsonConverterFactory.create(gson))
         .build()
 
-    private const val BASE_URL = "https://fill-in-13efb.web.app/api/"
+    const val BASE_URL = "https://fill-in-13efb.web.app/api/"
 }

--- a/app/src/main/java/com/teamfillin/fillin/config/di/RetrofitModule.kt
+++ b/app/src/main/java/com/teamfillin/fillin/config/di/RetrofitModule.kt
@@ -1,0 +1,51 @@
+package com.teamfillin.fillin.config.di
+
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.teamfillin.fillin.FlipperInitializer
+import com.teamfillin.fillin.data.interceptor.AuthInterceptor
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonModule::class)
+object RetrofitModule {
+    @Provides
+    @Singleton
+    fun provideAuthInterceptor(authInterceptor: AuthInterceptor): Interceptor = authInterceptor
+
+
+    @Provides
+    @Singleton
+    fun provideOkHttpInterceptor(
+        authInterceptor: Interceptor
+    ): OkHttpClient {
+        return OkHttpClient.Builder()
+            .addInterceptor(authInterceptor)
+            .apply { FlipperInitializer.addFlipperNetworkPlguin(this).build() }
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideGson(): Gson = GsonBuilder().setLenient().create()
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(
+        client: OkHttpClient,
+        gson: Gson
+    ): Retrofit = Retrofit.Builder()
+        .baseUrl(BASE_URL)
+        .client(client)
+        .addConverterFactory(GsonConverterFactory.create(gson))
+        .build()
+
+    private const val BASE_URL = "https://fill-in-13efb.web.app/api/"
+}

--- a/app/src/main/java/com/teamfillin/fillin/config/di/ServiceModule.kt
+++ b/app/src/main/java/com/teamfillin/fillin/config/di/ServiceModule.kt
@@ -1,0 +1,18 @@
+package com.teamfillin.fillin.config.di
+
+import com.teamfillin.fillin.data.service.AuthService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ServiceModule {
+    @Provides
+    @Singleton
+    fun provideAuthService(retrofit: Retrofit): AuthService =
+        retrofit.create(AuthService::class.java)
+}

--- a/app/src/main/java/com/teamfillin/fillin/config/di/SingletonModule.kt
+++ b/app/src/main/java/com/teamfillin/fillin/config/di/SingletonModule.kt
@@ -2,6 +2,7 @@ package com.teamfillin.fillin.config.di
 
 import android.app.Application
 import android.content.Context
+import com.teamfillin.fillin.data.local.FillInDataStore
 import com.teamfillin.fillin.design.ResolutionMetrics
 import dagger.Module
 import dagger.Provides
@@ -22,4 +23,8 @@ object SingletonModule {
     @Singleton
     fun provideResolutionMetrics(@ApplicationContext context: Application) =
         ResolutionMetrics(context)
+
+    @Provides
+    @Singleton
+    fun provideFillInDataStore(@ApplicationContext context: Context) = FillInDataStore(context)
 }

--- a/app/src/main/java/com/teamfillin/fillin/data/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/com/teamfillin/fillin/data/interceptor/AuthInterceptor.kt
@@ -51,11 +51,4 @@ class AuthInterceptor @Inject constructor(
         !originalRequest.url.encodedPath.contains("token") &&
                 originalRequest.url.encodedPath.contains("auth")
 
-    private fun Interceptor.Chain.proceedDeletingTokenOnError(request: Request): Response {
-        val response = proceed(request)
-        if (response.code == 401) {
-            localStorage.userToken = ""
-        }
-        return response
-    }
 }

--- a/app/src/main/java/com/teamfillin/fillin/data/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/com/teamfillin/fillin/data/interceptor/AuthInterceptor.kt
@@ -1,0 +1,16 @@
+package com.teamfillin.fillin.data.interceptor
+
+import com.teamfillin.fillin.data.local.FillInDataStore
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+
+class AuthInterceptor @Inject constructor(
+    private val localStorage: FillInDataStore
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val authRequest = chain.request().newBuilder()
+            .addHeader("token", localStorage.userToken).build()
+        return chain.proceed(authRequest)
+    }
+}

--- a/app/src/main/java/com/teamfillin/fillin/data/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/com/teamfillin/fillin/data/interceptor/AuthInterceptor.kt
@@ -1,16 +1,61 @@
 package com.teamfillin.fillin.data.interceptor
 
+import com.google.gson.Gson
+import com.teamfillin.fillin.config.di.RetrofitModule.BASE_URL
 import com.teamfillin.fillin.data.local.FillInDataStore
+import com.teamfillin.fillin.data.response.ResponseRefresh
 import okhttp3.Interceptor
+import okhttp3.Request
 import okhttp3.Response
 import javax.inject.Inject
 
 class AuthInterceptor @Inject constructor(
-    private val localStorage: FillInDataStore
+    private val localStorage: FillInDataStore,
+    private val gson: Gson
 ) : Interceptor {
+
     override fun intercept(chain: Interceptor.Chain): Response {
-        val authRequest = chain.request().newBuilder()
-            .addHeader("token", localStorage.userToken).build()
-        return chain.proceed(authRequest)
+        val originalRequest = chain.request()
+        val authRequest = if (isLogin(originalRequest)) originalRequest else
+            originalRequest.newBuilder().addHeader("token", localStorage.userToken).build()
+        val response = chain.proceed(authRequest)
+        when (response.code) {
+            401 -> {
+                val refreshTokenRequest = originalRequest.newBuilder().get()
+                    .url("${BASE_URL}auth/token")
+                    .addHeader("accesstoken", localStorage.userToken)
+                    .addHeader("refreshtoken", localStorage.refreshToken)
+                    .build()
+                val refreshTokenResponse = chain.proceed(refreshTokenRequest)
+
+                if (refreshTokenResponse.isSuccessful) {
+                    val refreshToken = gson.fromJson(
+                        refreshTokenResponse.body?.string(),
+                        ResponseRefresh::class.java
+                    )
+                    with(localStorage) {
+                        userToken = refreshToken.tokens.newAccessToken
+                        this.refreshToken = refreshToken.tokens.refreshToken
+                    }
+                    val newRequest = originalRequest.newBuilder()
+                        .addHeader("token", localStorage.userToken)
+                        .build()
+                    return chain.proceed(newRequest)
+                }
+            }
+        }
+        return response
+    }
+
+    private fun isLogin(originalRequest: Request) =
+        !originalRequest.url.encodedPath.contains("token") &&
+                originalRequest.url.encodedPath.contains("auth")
+
+    private fun Interceptor.Chain.proceedDeletingTokenOnError(request: Request): Response {
+        val response = proceed(request)
+        if (response.code == 401) {
+            localStorage.userToken = ""
+        }
+        return response
     }
 }

--- a/app/src/main/java/com/teamfillin/fillin/data/local/FillInDataStore.kt
+++ b/app/src/main/java/com/teamfillin/fillin/data/local/FillInDataStore.kt
@@ -31,4 +31,8 @@ class FillInDataStore @Inject constructor(
     var refreshToken: String
         set(value) = dataStore.edit { putString("REFRESH_TOKEN", value) }
         get() = dataStore.getString("REFRESH_TOKEN", "") ?: ""
+
+    var nickname: String
+        set(value) = dataStore.edit { putString("NICKNAME", value) }
+        get() = dataStore.getString("NICKNAME", "") ?: ""
 }

--- a/app/src/main/java/com/teamfillin/fillin/data/local/FillInDataStore.kt
+++ b/app/src/main/java/com/teamfillin/fillin/data/local/FillInDataStore.kt
@@ -1,0 +1,34 @@
+package com.teamfillin.fillin.data.local
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+import com.teamfillin.fillin.BuildConfig
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+const val FILE_NAME = "FILLINDATASTORE"
+
+class FillInDataStore @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val dataStore: SharedPreferences =
+        if (BuildConfig.DEBUG) context.getSharedPreferences(FILE_NAME, Context.MODE_PRIVATE)
+        else EncryptedSharedPreferences.create(
+            FILE_NAME,
+            MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
+            context,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+
+    var userToken: String
+        set(value) = dataStore.edit { putString("USER_TOKEN", value) }
+        get() = dataStore.getString("USER_TOKEN", "") ?: ""
+
+    var refreshToken: String
+        set(value) = dataStore.edit { putString("REFRESH_TOKEN", value) }
+        get() = dataStore.getString("REFRESH_TOKEN", "") ?: ""
+}

--- a/app/src/main/java/com/teamfillin/fillin/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/teamfillin/fillin/data/repository/AuthRepositoryImpl.kt
@@ -2,7 +2,9 @@ package com.teamfillin.fillin.data.repository
 
 import com.teamfillin.fillin.data.local.FillInDataStore
 import com.teamfillin.fillin.data.response.ResponseAuth
+import com.teamfillin.fillin.data.response.toEntity
 import com.teamfillin.fillin.data.service.AuthService
+import com.teamfillin.fillin.domain.entity.Auth
 import com.teamfillin.fillin.domain.repository.AuthRepository
 import retrofit2.await
 import timber.log.Timber
@@ -12,19 +14,16 @@ class AuthRepositoryImpl @Inject constructor(
     private val dataStore: FillInDataStore,
     private val service: AuthService
 ) : AuthRepository {
-    override suspend fun login(token: String): Result<Boolean> {
+    override suspend fun login(token: String) {
         runCatching {
             service.login(token).await()
         }.fold({
+            val auth = it.data.toEntity()
             with(dataStore) {
-                userToken = it.data.accessToken
-                refreshToken = it.data.refreshToken
+                userToken = auth.accessToken
+                refreshToken = auth.refreshToken
             }
-            if (it.data is ResponseAuth.SignUp) dataStore.nickname = it.data.nickName
-            return Result.success(true)
-        }, {
-            Timber.e(it)
-            return Result.failure(it)
-        })
+            if (auth is Auth.SignUp) dataStore.nickname = auth.nickName
+        }, Timber::e)
     }
 }

--- a/app/src/main/java/com/teamfillin/fillin/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/teamfillin/fillin/data/repository/AuthRepositoryImpl.kt
@@ -14,7 +14,7 @@ class AuthRepositoryImpl @Inject constructor(
 ) : AuthRepository {
     override suspend fun login(token: String): Result<Boolean> {
         runCatching {
-            service.login(hashMapOf("token" to token, "social" to "kakao")).await()
+            service.login(token).await()
         }.fold({
             with(dataStore) {
                 userToken = it.data.accessToken

--- a/app/src/main/java/com/teamfillin/fillin/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/teamfillin/fillin/data/repository/AuthRepositoryImpl.kt
@@ -1,0 +1,28 @@
+package com.teamfillin.fillin.data.repository
+
+import com.teamfillin.fillin.data.local.FillInDataStore
+import com.teamfillin.fillin.data.response.ResponseAuth
+import com.teamfillin.fillin.data.service.AuthService
+import com.teamfillin.fillin.domain.repository.AuthRepository
+import retrofit2.await
+import javax.inject.Inject
+
+class AuthRepositoryImpl @Inject constructor(
+    private val dataStore: FillInDataStore,
+    private val service: AuthService
+) : AuthRepository {
+    override suspend fun login(token: String): Result<Boolean> {
+        runCatching {
+            service.login(hashMapOf("token" to token, "social" to "kakao")).await()
+        }.fold({
+            with(dataStore) {
+                userToken = it.data.accessToken
+                refreshToken = it.data.refreshToken
+            }
+            if (it.data is ResponseAuth.SignUp) dataStore.nickname = it.data.nickName
+            return Result.success(true)
+        }, {
+            return Result.failure(it)
+        })
+    }
+}

--- a/app/src/main/java/com/teamfillin/fillin/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/teamfillin/fillin/data/repository/AuthRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.teamfillin.fillin.data.response.ResponseAuth
 import com.teamfillin.fillin.data.service.AuthService
 import com.teamfillin.fillin.domain.repository.AuthRepository
 import retrofit2.await
+import timber.log.Timber
 import javax.inject.Inject
 
 class AuthRepositoryImpl @Inject constructor(
@@ -22,6 +23,7 @@ class AuthRepositoryImpl @Inject constructor(
             if (it.data is ResponseAuth.SignUp) dataStore.nickname = it.data.nickName
             return Result.success(true)
         }, {
+            Timber.e(it)
             return Result.failure(it)
         })
     }

--- a/app/src/main/java/com/teamfillin/fillin/data/response/BaseResponse.kt
+++ b/app/src/main/java/com/teamfillin/fillin/data/response/BaseResponse.kt
@@ -1,0 +1,8 @@
+package com.teamfillin.fillin.data.response
+
+data class BaseResponse<T>(
+    val status: Int,
+    val success: Boolean,
+    val message: String,
+    val data: T
+)

--- a/app/src/main/java/com/teamfillin/fillin/data/response/ResponseAuth.kt
+++ b/app/src/main/java/com/teamfillin/fillin/data/response/ResponseAuth.kt
@@ -1,20 +1,15 @@
 package com.teamfillin.fillin.data.response
 
-sealed class ResponseAuth(
-    open val email: String?,
-    open val accessToken: String,
-    open val refreshToken: String
-) {
-    data class Login(
-        override val email: String?,
-        override val accessToken: String,
-        override val refreshToken: String
-    ) : ResponseAuth(email, accessToken, refreshToken)
+import com.teamfillin.fillin.domain.entity.Auth
 
-    data class SignUp(
-        override val email: String?,
-        val nickName: String,
-        override val accessToken: String,
-        override val refreshToken: String
-    ) : ResponseAuth(email, accessToken, refreshToken)
+data class ResponseAuth(
+    val email: String?,
+    val nickName: String? = null,
+    val accessToken: String,
+    val refreshToken: String
+)
+
+fun ResponseAuth.toEntity(): Auth = when (nickName) {
+    null -> Auth.Login(email, accessToken, refreshToken)
+    else -> Auth.SignUp(email, nickName, accessToken, refreshToken)
 }

--- a/app/src/main/java/com/teamfillin/fillin/data/response/ResponseAuth.kt
+++ b/app/src/main/java/com/teamfillin/fillin/data/response/ResponseAuth.kt
@@ -1,0 +1,20 @@
+package com.teamfillin.fillin.data.response
+
+sealed class ResponseAuth(
+    open val email: String?,
+    open val accessToken: String,
+    open val refreshToken: String
+) {
+    data class Login(
+        override val email: String?,
+        override val accessToken: String,
+        override val refreshToken: String
+    ) : ResponseAuth(email, accessToken, refreshToken)
+
+    data class SignUp(
+        override val email: String?,
+        val nickName: String,
+        override val accessToken: String,
+        override val refreshToken: String
+    ) : ResponseAuth(email, accessToken, refreshToken)
+}

--- a/app/src/main/java/com/teamfillin/fillin/data/response/ResponseRefresh.kt
+++ b/app/src/main/java/com/teamfillin/fillin/data/response/ResponseRefresh.kt
@@ -1,0 +1,16 @@
+package com.teamfillin.fillin.data.response
+
+import com.google.gson.annotations.SerializedName
+
+data class ResponseRefresh(
+    val status: Int,
+    val success: Boolean,
+    val message: String,
+    val tokens: AuthToken
+) {
+    data class AuthToken(
+        val newAccessToken: String,
+        @SerializedName("refreshtoken")
+        val refreshToken: String
+    )
+}

--- a/app/src/main/java/com/teamfillin/fillin/data/service/AuthService.kt
+++ b/app/src/main/java/com/teamfillin/fillin/data/service/AuthService.kt
@@ -3,9 +3,10 @@ package com.teamfillin.fillin.data.service
 import com.teamfillin.fillin.data.response.BaseResponse
 import com.teamfillin.fillin.data.response.ResponseAuth
 import retrofit2.Call
+import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface AuthService {
     @POST("auth")
-    fun login(request: HashMap<String, String>): Call<BaseResponse<ResponseAuth>>
+    fun login(@Body request: HashMap<String, String>): Call<BaseResponse<ResponseAuth>>
 }

--- a/app/src/main/java/com/teamfillin/fillin/data/service/AuthService.kt
+++ b/app/src/main/java/com/teamfillin/fillin/data/service/AuthService.kt
@@ -4,14 +4,15 @@ import com.teamfillin.fillin.data.response.BaseResponse
 import com.teamfillin.fillin.data.response.ResponseAuth
 import com.teamfillin.fillin.data.response.ResponseRefresh
 import retrofit2.Call
-import retrofit2.http.Body
-import retrofit2.http.GET
-import retrofit2.http.Header
-import retrofit2.http.POST
+import retrofit2.http.*
 
 interface AuthService {
+    @FormUrlEncoded
     @POST("auth")
-    fun login(@Body request: HashMap<String, String>): Call<BaseResponse<ResponseAuth>>
+    fun login(
+        @Field("token") token: String,
+        @Field("social") social: String = "kakao"
+    ): Call<BaseResponse<ResponseAuth>>
 
     @GET("auth/token")
     fun refresh(

--- a/app/src/main/java/com/teamfillin/fillin/data/service/AuthService.kt
+++ b/app/src/main/java/com/teamfillin/fillin/data/service/AuthService.kt
@@ -1,0 +1,11 @@
+package com.teamfillin.fillin.data.service
+
+import com.teamfillin.fillin.data.response.BaseResponse
+import com.teamfillin.fillin.data.response.ResponseAuth
+import retrofit2.Call
+import retrofit2.http.POST
+
+interface AuthService {
+    @POST("auth")
+    fun login(request: HashMap<String, String>): Call<BaseResponse<ResponseAuth>>
+}

--- a/app/src/main/java/com/teamfillin/fillin/data/service/AuthService.kt
+++ b/app/src/main/java/com/teamfillin/fillin/data/service/AuthService.kt
@@ -2,11 +2,20 @@ package com.teamfillin.fillin.data.service
 
 import com.teamfillin.fillin.data.response.BaseResponse
 import com.teamfillin.fillin.data.response.ResponseAuth
+import com.teamfillin.fillin.data.response.ResponseRefresh
 import retrofit2.Call
 import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.POST
 
 interface AuthService {
     @POST("auth")
     fun login(@Body request: HashMap<String, String>): Call<BaseResponse<ResponseAuth>>
+
+    @GET("auth/token")
+    fun refresh(
+        @Header("accesstoken") accessToken: String,
+        @Header("refreshtoken") refreshToken: String
+    ): Call<BaseResponse<ResponseRefresh>>
 }

--- a/app/src/main/java/com/teamfillin/fillin/domain/entity/Auth.kt
+++ b/app/src/main/java/com/teamfillin/fillin/domain/entity/Auth.kt
@@ -1,0 +1,20 @@
+package com.teamfillin.fillin.domain.entity
+
+sealed class Auth(
+    open val email: String?,
+    open val accessToken: String,
+    open val refreshToken: String
+) {
+    data class Login(
+        override val email: String?,
+        override val accessToken: String,
+        override val refreshToken: String
+    ) : Auth(email, accessToken, refreshToken)
+
+    data class SignUp(
+        override val email: String?,
+        val nickName: String,
+        override val accessToken: String,
+        override val refreshToken: String
+    ) : Auth(email, accessToken, refreshToken)
+}

--- a/app/src/main/java/com/teamfillin/fillin/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/teamfillin/fillin/domain/repository/AuthRepository.kt
@@ -1,0 +1,5 @@
+package com.teamfillin.fillin.domain.repository
+
+interface AuthRepository {
+    suspend fun login(token: String): Result<Boolean>
+}

--- a/app/src/main/java/com/teamfillin/fillin/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/teamfillin/fillin/domain/repository/AuthRepository.kt
@@ -1,5 +1,5 @@
 package com.teamfillin.fillin.domain.repository
 
 interface AuthRepository {
-    suspend fun login(token: String): Result<Boolean>
+    suspend fun login(token: String)
 }

--- a/app/src/main/java/com/teamfillin/fillin/presentation/login/LoginActivity.kt
+++ b/app/src/main/java/com/teamfillin/fillin/presentation/login/LoginActivity.kt
@@ -34,17 +34,18 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
                 .flowWithLifecycle(lifecycle)
                 .collect {
                     when (it) {
-                        is KakaoAuthService.LoginState.Success -> {
-                            Timber.d("Kakao Login Success ${it.token}")
-                            viewModel.login(it.token)
-                        }
+                        is KakaoAuthService.LoginState.Success -> viewModel.login(it.token)
                         is KakaoAuthService.LoginState.Failure -> Timber.d("Kakao Login Failed ${it.error}")
                         else -> Timber.d("Kakao INIT")
                     }
                 }
+        }
+
+        lifecycleScope.launch {
             viewModel.loginResult
                 .flowWithLifecycle(lifecycle)
                 .collect {
+                    Timber.d("Nunu inHouseLogin $it")
                     when (it) {
                         is LoginViewModel.InHouseLoginState.Success -> toast("로그인 성공")
                         is LoginViewModel.InHouseLoginState.Failure -> toast(it.message)

--- a/app/src/main/java/com/teamfillin/fillin/presentation/login/LoginActivity.kt
+++ b/app/src/main/java/com/teamfillin/fillin/presentation/login/LoginActivity.kt
@@ -1,10 +1,12 @@
 package com.teamfillin.fillin.presentation.login
 
 import android.os.Bundle
+import androidx.activity.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.teamfillin.fillin.R
 import com.teamfillin.fillin.core.base.BindingActivity
+import com.teamfillin.fillin.core.context.toast
 import com.teamfillin.fillin.databinding.ActivityLoginBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -15,6 +17,8 @@ import javax.inject.Inject
 class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_login) {
     @Inject
     lateinit var kakaoAuthService: KakaoAuthService
+    private val viewModel by viewModels<LoginViewModel>()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding.txtHello.setOnClickListener {
@@ -30,9 +34,20 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
                 .flowWithLifecycle(lifecycle)
                 .collect {
                     when (it) {
-                        is KakaoAuthService.LoginState.Success -> Timber.d("Kakao Login Success ${it.token}")
+                        is KakaoAuthService.LoginState.Success -> {
+                            Timber.d("Kakao Login Success ${it.token}")
+                            viewModel.login(it.token)
+                        }
                         is KakaoAuthService.LoginState.Failure -> Timber.d("Kakao Login Failed ${it.error}")
                         else -> Timber.d("Kakao INIT")
+                    }
+                }
+            viewModel.loginResult
+                .flowWithLifecycle(lifecycle)
+                .collect {
+                    when (it) {
+                        is LoginViewModel.InHouseLoginState.Success -> toast("로그인 성공")
+                        is LoginViewModel.InHouseLoginState.Failure -> toast(it.message)
                     }
                 }
         }

--- a/app/src/main/java/com/teamfillin/fillin/presentation/login/LoginViewModel.kt
+++ b/app/src/main/java/com/teamfillin/fillin/presentation/login/LoginViewModel.kt
@@ -1,0 +1,39 @@
+package com.teamfillin.fillin.presentation.login
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.teamfillin.fillin.domain.repository.AuthRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class LoginViewModel @Inject constructor(
+    private val authRepository: AuthRepository
+) : ViewModel() {
+    private val _loginResult: MutableStateFlow<InHouseLoginState> =
+        MutableStateFlow(InHouseLoginState.Init)
+    val loginResult: StateFlow<InHouseLoginState> = _loginResult.asStateFlow()
+
+    fun login(token: String) {
+        viewModelScope.launch {
+            runCatching { authRepository.login(token) }
+                .fold({
+                    _loginResult.value = InHouseLoginState.Success
+                }, {
+                    _loginResult.value = InHouseLoginState.Failure(it.message ?: "로그인에 실패했습니다")
+                    Timber.e(it)
+                })
+        }
+    }
+
+    sealed class InHouseLoginState {
+        object Init : InHouseLoginState()
+        object Success : InHouseLoginState()
+        data class Failure(val message: String) : InHouseLoginState()
+    }
+}


### PR DESCRIPTION
## Related Issues
close #22 

## What Did You Do?
- [x] 카카오 소셜로그인 및 인하우스 서버로 로그인/회원가입 구현
- [x] 모든 API에서 토큰 만료시 토큰을 자동으로 재발급할 수 있는 기능 구현
- [x] DI로 Retrofit/Service/Repository/ViewModel Layer 구성
- [x] Local에서 사용할 수 있는 SharedPreference(릴리즈 시 EncryptedSharedPreference) 구현

